### PR TITLE
Removed the tooltip from RECESS column

### DIFF
--- a/client/src/components/TimeTable/index.jsx
+++ b/client/src/components/TimeTable/index.jsx
@@ -34,9 +34,7 @@ const TimeTable = ({ semester, stream, section }) => {
 										</TableCell>
 									</Tooltip>
 								))}
-								<Tooltip title="Faculty Name" placement="top-end" arrow>
-									<TableCell />
-								</Tooltip>
+								<TableCell />
 								{subjects.periods.slice(4).map(subject => (
 									<Tooltip title="Faculty Name" key={subject} placement="top-end" arrow>
 										<TableCell key={subject} align="center">


### PR DESCRIPTION
# Issue  📐

- **I anuj98 have worked for #57 **

[put x to check the boxes]: <> (This is a comment, it will not be included)

## Guidelines 🔐

**I accept the fact that i have followed the guidelines and have not copied the codes from around the internet**

- [x] **Contribution Guidelines**
- [x] **Code of Conduct**

## Issue to be closed 🛅

- **My pull request closes #57**

## Screenshots 📷

**Here are the pictures of changes that i have made 🔽**

Other columns:
<img width="939" alt="image" src="https://user-images.githubusercontent.com/30874550/188298849-90a0f7e4-5829-4ea9-8774-208fef2ac25d.png">

Break column:
<img width="921" alt="image" src="https://user-images.githubusercontent.com/30874550/188298855-42e056cd-a296-4c60-a94d-5ea9b060cf67.png">

  
  
  
---
